### PR TITLE
feat: 팀별 일정 조회 api 연동

### DIFF
--- a/src/api/league-game/league-games.ts
+++ b/src/api/league-game/league-games.ts
@@ -4,11 +4,13 @@ import {
   TGameByLeagueGameId,
   TGameListByDate,
   TGameListByLeagueIdYearMonth,
+  TGameListByLeagueTeamId,
 } from '@/types/league-games';
 import { GetGameByLeagueGameIdProps } from '@/api/league-game/use-get-game-by-league-game-id';
 import { GetGameListByLeagueGameIdYearMonthProps } from '@/api/league-game/use-get-game-list-by-league-game-id-year-month';
 import { GetGameListByDateProps } from '@/api/league-game/use-get-game-list-by-date';
 import { GetAllGameList } from '@/api/league-game/use-get-all-game-list';
+import { GetGameListByTeamIdProps } from '@/api/league-game/use-get-game-list-by-team-id';
 
 const ENDPOINT = '/league-game/search';
 
@@ -20,25 +22,25 @@ export async function getGameByLeagueGameId({ leagueGameId }: GetGameByLeagueGam
 }
 
 // 특정 팀 경기들 조회
-export async function getGameByTeamId() {
-  //   {
-  //   leagueTeamId,
-  //   size,
-  //   sort,
-  //   page,
-  // }: GetGameListByTeamIdProps
-  // Todo: teamId api 생길시 수정 필요
-  const { data } = await instance.get<TGameByLeagueGameId>(`${ENDPOINT}/team/${1}`, {
+export async function getGameByTeamId({
+  leagueTeamId,
+  size,
+  sort,
+  page,
+}: GetGameListByTeamIdProps) {
+  const { data } = await instance.get<TGameListByLeagueTeamId>(`${ENDPOINT}/team/${leagueTeamId}`, {
     params: {
       pageable: {
-        page: 0,
-        size: 10,
-        sort: ['string'],
+        page,
+        size,
+        sort,
       },
     },
   });
 
-  return data.response;
+  const { findLeagueGames, totalElements, totalPages } = data;
+
+  return { findLeagueGames, totalElements, totalPages };
 }
 
 // 특정 년월 경기들 조회

--- a/src/api/league-game/use-get-game-list-by-team-id.tsx
+++ b/src/api/league-game/use-get-game-list-by-team-id.tsx
@@ -7,7 +7,7 @@ type TSortArray<T extends 'string' | 'number'> = T[];
 
 export type GetGameListByTeamIdProps = {
   leagueTeamId: number;
-  sort: TSortArray<'string' | 'number'>;
+  sort?: TSortArray<'string' | 'number'>;
   page?: number;
   size?: number;
 };
@@ -18,14 +18,12 @@ export function getQueryKey({ leagueTeamId, size, sort, page }: GetGameListByTea
 
 export default function useGetGameListByTeamId({
   leagueTeamId,
-  size,
-  sort,
-  page,
+  size = 10,
+  sort = ['string'],
+  page = 0,
 }: GetGameListByTeamIdProps) {
   return useQuery({
     queryKey: getQueryKey({ leagueTeamId, sort, page, size }),
-    // Todo: 임시 주석
-    // queryFn: () => getGameByTeamId({ leagueTeamId, sort, page, size }),
-    queryFn: () => getGameByTeamId(),
+    queryFn: () => getGameByTeamId({ leagueTeamId, sort, page, size }),
   });
 }

--- a/src/components/league-game/league-game.tsx
+++ b/src/components/league-game/league-game.tsx
@@ -16,13 +16,23 @@ export default function LeagueGame() {
   const [selectedTeamId, setSelectedTeamId] = useState(20);
   const [selectedYearMonthDate, setSelectedYearMonthDate] = useState(todayDate);
 
-  const { isPending, data, error } = useGetGameListByLeagueGameIdYearMonth({
+  const {
+    isPending: gameListIsPending,
+    data: gameList,
+    error: gameListError,
+  } = useGetGameListByLeagueGameIdYearMonth({
     leagueId: PREMIER_LEAGUE_ID,
     yearMonth: shortISOYearMonth(selectedYearMonthDate),
   });
 
-  if (!gameListService.hasGameList() && data) {
-    gameListService.setGameList(data);
+  // const {
+  //   isPending: gameListByLeagueTeamIdIsPending,
+  //   data: gameListByLeagueTeamId,
+  //   error: gameListByLeagueTeamIdError,
+  // } = useGetGameListByTeamId({ leagueTeamId: 1 });
+
+  if (!gameListService.hasGameList() && gameList) {
+    gameListService.setGameList(gameList);
   }
 
   function handleSelectYearMonth(date: Date) {
@@ -41,12 +51,25 @@ export default function LeagueGame() {
         selectedYearMonthDate={selectedYearMonthDate}
       />
       <TeamList onSelectedTeamId={handleSelectTeamId} selectedTeamId={selectedTeamId} />
-
-      {isPending ? <Loading /> : null}
-      {error ? <div>Error</div> : null}
-      {gameListService.hasGameList() ? (
-        <LeagueGameContentList monthlyGameList={gameListService.sortedMonthlyGameList} />
-      ) : null}
+      {
+        selectedTeamId === 20 ? (
+          <>
+            {gameListIsPending ? <Loading /> : null}
+            {gameListError ? <div>Error</div> : null}
+            {gameListService.hasGameList() ? (
+              <LeagueGameContentList monthlyGameList={gameListService.sortedMonthlyGameList} />
+            ) : null}
+          </>
+        ) : null
+        // Todo: 팀 월별 경기 일정 조회 api 필요
+        // <>
+        //   {gameListByLeagueTeamIdIsPending ? <Loading /> : null}
+        //   {gameListByLeagueTeamIdError ? <div>Error</div>  : null}
+        //   {gameListByLeagueTeamId ? (
+        //     <LeagueGameContentList monthlyGameList={gameListByLeagueTeamId} />
+        //   ) : null}
+        // </>
+      }
     </>
   );
 }

--- a/src/components/league-game/service/game-list.ts
+++ b/src/components/league-game/service/game-list.ts
@@ -1,18 +1,19 @@
-// 월 단위 경기 일정 정보 리스트를 받아 관련 정보를 반환하는 Class
-
+import { shortISO, makeDayObject } from '@/utils/date-helper';
 import { TGameListWithDate } from '@/types/league-games';
-import { makeDayObject, shortISO, TDate } from '@/utils/date-helper';
 
-function compareDates(a: TGameListWithDate, b: TGameListWithDate) {
+type TDateComparable = {
+  date: string;
+};
+
+function compareDates<T extends TDateComparable>(a: T, b: T) {
   const dateA = new Date(a.date);
   const dateB = new Date(b.date);
-
   return dateA.getTime() - dateB.getTime();
 }
 
-export class GameListService {
-  private gameList: TGameListWithDate[];
-  private sortedGameList: TGameListWithDate[] = [];
+export class GameListService<T extends TGameListWithDate> {
+  private gameList: T[];
+  private sortedGameList: T[] = [];
 
   constructor() {
     this.gameList = [];
@@ -24,22 +25,14 @@ export class GameListService {
     }
   }
 
-  setGameList(gameList: TGameListWithDate[]) {
+  setGameList(gameList: T[]) {
     this.gameList = gameList;
-
     this.sortGameList();
   }
 
   getGameListOfDay(targetDate: Date) {
-    // 특정 날짜의 경기 일정을 불러오는 함수
-    // targetDate : "2024-02-01" 형식의 문자열을 인수로 받는다.
-
-    for (const element of this.sortedGameList) {
-      if (element.date === shortISO(targetDate)) {
-        return element.games;
-      }
-    }
-    return [];
+    const targetDateString = shortISO(targetDate);
+    return this.sortedGameList.find((element) => element.date === targetDateString)?.games || [];
   }
 
   hasGameList() {
@@ -47,25 +40,17 @@ export class GameListService {
   }
 
   get dateList() {
-    const list: TDate[] = [];
-
-    for (const element of this.sortedGameList) {
-      list.push(makeDayObject(element.date));
-    }
-
-    return list;
+    return this.sortedGameList.map((element) => makeDayObject(element.date));
   }
 
   get firstDate() {
-    if (this.hasGameList()) {
-      return new Date(this.sortedGameList[0].date);
-    }
+    return this.hasGameList() ? new Date(this.sortedGameList[0].date) : undefined;
   }
 
   get lastDate() {
-    if (this.hasGameList()) {
-      return new Date(this.sortedGameList[-1].date);
-    }
+    return this.hasGameList()
+      ? new Date(this.sortedGameList[this.sortedGameList.length - 1].date)
+      : undefined;
   }
 
   get monthlyGameList() {

--- a/src/components/league-game/team-list.tsx
+++ b/src/components/league-game/team-list.tsx
@@ -90,7 +90,7 @@ export default function TeamList({ onSelectedTeamId, selectedTeamId }: TeamListP
         {teams.map((team) => (
           <div className="w-1/10 flex-shrink-0" key={team.teamId}>
             <TeamLogo
-              logo={team.logo}
+              // logo={team.logo}
               name={team.name}
               onSelectedTeamId={onSelectedTeamId}
               selectedTeamId={selectedTeamId}

--- a/src/components/league-game/team-logo.tsx
+++ b/src/components/league-game/team-logo.tsx
@@ -4,7 +4,7 @@ import cimg from '@/assets/Chelsea.png';
 
 type TeamLogoProps = {
   name: string;
-  logo: string;
+  // logo: string;
   teamId: number;
   onSelectedTeamId: (teamId: number) => void;
   selectedTeamId: number;
@@ -14,11 +14,10 @@ export default function TeamLogo({
   selectedTeamId,
   onSelectedTeamId,
   name,
-  logo,
+  // logo,
   teamId,
 }: TeamLogoProps) {
   // Todo: 로고 받아야함
-  console.log(logo);
 
   return (
     <div className="flex h-20 w-24 flex-col items-center">

--- a/src/types/league-games.ts
+++ b/src/types/league-games.ts
@@ -115,3 +115,5 @@ export type TAllGameList = {
   totalElements: number;
   totalPages: number;
 };
+
+export type TGameListByLeagueTeamId = TAllGameList;


### PR DESCRIPTION
## 개요
팀별 일정 조회 api 연동

## 작업 사항
- api 연동
- GameListService 코드 수정

## 관련 이슈
- 월별 팀별 일정 api 필요.
- 해당 api 응답값과 기존 league game list의 양식이 맞지 않아 UI로 보여주지 않음.
- api 교체 필요