### PR TITLE
토큰 초기화 이슈

### DIFF
--- a/src/components/main-header/main-nav.tsx
+++ b/src/components/main-header/main-nav.tsx
@@ -6,10 +6,10 @@ import NavLinkList from '@/components/main-header/nav-link-list';
 import { useAuth } from '@/contexts/auth-context';
 
 export default function MainNav() {
-  const { isAuthenticated, setIsAuthenticated } = useAuth();
+  const { isAuthenticated, logout } = useAuth();
 
   function handleLogout() {
-    setIsAuthenticated(false);
+    logout();
   }
 
   return (

--- a/src/components/main-header/mobile-nav.tsx
+++ b/src/components/main-header/mobile-nav.tsx
@@ -8,7 +8,7 @@ import ModalNav from '@/components/main-header/modal-nav';
 import { useAuth } from '@/contexts/auth-context';
 
 export default function MobileNav() {
-  const { isAuthenticated, setIsAuthenticated } = useAuth();
+  const { isAuthenticated, logout } = useAuth();
   const [modalOpen, setModalOpen] = useState(false);
 
   function openModal() {
@@ -20,7 +20,7 @@ export default function MobileNav() {
   }
 
   function handleLogout() {
-    setIsAuthenticated(false);
+    logout();
   }
 
   return (

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -23,6 +23,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const { isAuthenticated, setIsAuthenticated } = useAuthValidation();
 
   function logout() {
+    setIsAuthenticated(false);
     setAuthHeader('');
     setToken('');
   }

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -2,10 +2,14 @@
 
 import React, { createContext, ReactNode } from 'react';
 import useAuthValidation from '@/hooks/use-auth-validation';
+import useLocalStorage from '@/hooks/use-local-storage';
+import { setAuthHeader } from '@/api/auth/auths';
+import { TOKEN_KEY } from '@/constants/auth';
 
 type TAuthContext = {
   isAuthenticated: boolean;
   setIsAuthenticated: React.Dispatch<React.SetStateAction<boolean>>;
+  logout: () => void;
 };
 
 const AuthContext = createContext<TAuthContext | undefined>(undefined);
@@ -15,10 +19,16 @@ type AuthProviderProps = {
 };
 
 export function AuthProvider({ children }: AuthProviderProps) {
+  const [, setToken] = useLocalStorage<string>(TOKEN_KEY, '');
   const { isAuthenticated, setIsAuthenticated } = useAuthValidation();
 
+  function logout() {
+    setAuthHeader('');
+    setToken('');
+  }
+
   return (
-    <AuthContext.Provider value={{ isAuthenticated, setIsAuthenticated }}>
+    <AuthContext.Provider value={{ isAuthenticated, setIsAuthenticated, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/hooks/use-auth-validation.tsx
+++ b/src/hooks/use-auth-validation.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
 import useLocalStorage from '@/hooks/use-local-storage';
-import { TOKEN_KEY } from '@/constants/auth';
 import { setAuthHeader, validateToken } from '@/api/auth/auths';
+import { TOKEN_KEY } from '@/constants/auth';
 
 export default function useAuthValidation() {
-  const [token, setToken] = useLocalStorage<string>(TOKEN_KEY, '');
+  const [token] = useLocalStorage<string>(TOKEN_KEY, '');
   const [isAuthenticated, setIsAuthenticated] = useState(false);
 
   useEffect(() => {
@@ -21,13 +21,6 @@ export default function useAuthValidation() {
       }
     })();
   }, [token]);
-
-  useEffect(() => {
-    if (!isAuthenticated) {
-      setAuthHeader('');
-      setToken('');
-    }
-  }, [isAuthenticated]);
 
   return { isAuthenticated, setIsAuthenticated };
 }


### PR DESCRIPTION
## 개요
토큰이 매번 초기화 되어 수정
## 작업 사항
- 문제 코드
```ts
  // use-auth-validation.tsx
  useEffect(() => {
    if (!isAuthenticated) {
      setAuthHeader('');
      setToken('');
    }
  }, [isAuthenticated]);
```
로그아웃 시 isAuthenticated를 false로 변경하여 useEffect 내 로직이 실행되게 함.

그런데 isAuthenticated의 초기값이 false기 때문에 앱 실행 초기에 무조건 이 로직이 실행되어 로컬스토리지의 token과 header의 Authorization이 초기화 됨.

isAuthenticated의 초기값을 null로 두고 false일 때만 로그아웃을 처리해도 되지만
유효성 검사를 하는 useAuthValidation 훅에 로그아웃 로직이 포함되어 있는 것은 맞지 않다고 생각했고, useEffect가 아니라 로그아웃 버튼의 핸들러에서 로직이 실행되는 것이 맞다고 생각함.

따라서 AuthContext에 logout함수를 추가하고 제공하도록 수정

```ts
  // auth-context.tsx
  function logout() {
    setIsAuthenticated(false);
    setAuthHeader('');
    setToken('');
  }
```

## 관련 이슈
<!---- Resolves: #(Isuue Number) -->
Resolves: #107 