### PR TITLE
Feat/#123 헤더 구현, lint 오류 해결

### DIFF
--- a/src/components/main-header/modal-nav-link-list.tsx
+++ b/src/components/main-header/modal-nav-link-list.tsx
@@ -15,10 +15,10 @@ export default function ModalNavLinkList({ onCloseModal }: NavModalProps) {
             <li key={commonLink.href}>
               <Link
                 className={twMerge(
-                  `group mb-4 flex items-center font-semibold text-slate-700 transition-colors
-                  hover:text-slate-900 dark:text-sky-400 lg:text-sm lg:leading-6`,
+                  `group mb-4 flex items-center font-semibold text-slate-600 transition-colors hover:text-slate-900 lg:text-sm lg:leading-6`,
+                  'dark:text-slate-200',
                   pathname === commonLink.href
-                    ? 'border-slate-400 text-sky-400 hover:text-sky-400'
+                    ? 'border-slate-400 text-slate-900 hover:text-slate-900'
                     : null,
                 )}
                 href={commonLink.href}
@@ -44,9 +44,9 @@ export default function ModalNavLinkList({ onCloseModal }: NavModalProps) {
                   <li key={subLink.href}>
                     <Link
                       className={twMerge(
-                        '-ml-px block border-l border-transparent pl-4 text-slate-700 transition-colors hover:border-slate-400 hover:text-slate-900 dark:text-slate-400 dark:hover:border-slate-500 dark:hover:text-slate-300',
+                        '-ml-px block border-l border-transparent pl-4 text-slate-600 transition-colors hover:border-slate-400 hover:text-slate-900 dark:text-slate-400 dark:hover:border-slate-500 dark:hover:text-slate-300',
                         pathname === subLink.href
-                          ? 'border-slate-400 text-sky-400 hover:text-sky-400'
+                          ? 'border-slate-400 text-slate-900 hover:text-slate-900'
                           : null,
                       )}
                       href={subLink.href}

--- a/src/components/main-header/nav-link-item.tsx
+++ b/src/components/main-header/nav-link-item.tsx
@@ -1,15 +1,21 @@
 import { IconCaretDownFilled, IconCaretUpFilled } from '@tabler/icons-react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import NavSubLinkList from '@/components/main-header/nav-sub-link-list';
 import { TLink } from '@/components/main-header/link-list-util';
+import { cn } from '@/utils/cn';
 
 type NavLinkItemProps = { link: TLink };
 
 export default function NavLinkItem({ link }: NavLinkItemProps) {
+  const isSamePath = usePathname().split('/')[1] === link.href.split('/')[1];
+
   return (
     <div className="group flex h-full items-center text-slate-300 hover:text-white">
       <Link className="flex cursor-pointer" href={link.href}>
-        <div className="font-bold">{link.name}</div>
+        <div className={cn('font-bold', isSamePath && 'text-white hover:text-white')}>
+          {link.name}
+        </div>
         {link.subLinkList.length > 0 ? (
           <>
             <IconCaretDownFilled className="group-hover:hidden" />

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-/* eslint-disable */
-
 import * as React from 'react';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { Check, ChevronRight, Circle } from 'lucide-react';
@@ -27,12 +25,12 @@ const DropdownMenuSubTrigger = React.forwardRef<
   }
 >(({ className, inset, children, ...props }, ref) => (
   <DropdownMenuPrimitive.SubTrigger
-    ref={ref}
     className={cn(
       'rounded-sm flex cursor-default select-none items-center px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent',
       inset && 'pl-8',
       className,
     )}
+    ref={ref}
     {...props}
   >
     {children}
@@ -46,11 +44,11 @@ const DropdownMenuSubContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
-    ref={ref}
     className={cn(
       'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className,
     )}
+    ref={ref}
     {...props}
   />
 ));
@@ -62,12 +60,12 @@ const DropdownMenuContent = React.forwardRef<
 >(({ className, sideOffset = 4, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
     <DropdownMenuPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
       className={cn(
         'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className,
       )}
+      ref={ref}
+      sideOffset={sideOffset}
       {...props}
     />
   </DropdownMenuPrimitive.Portal>
@@ -81,12 +79,12 @@ const DropdownMenuItem = React.forwardRef<
   }
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
-    ref={ref}
     className={cn(
       'rounded-sm relative flex cursor-pointer select-none items-center px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       inset && 'pl-8',
       className,
     )}
+    ref={ref}
     {...props}
   />
 ));
@@ -97,12 +95,12 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
 >(({ className, children, checked, ...props }, ref) => (
   <DropdownMenuPrimitive.CheckboxItem
-    ref={ref}
+    checked={checked}
     className={cn(
       'rounded-sm relative flex cursor-default select-none items-center py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
-    checked={checked}
+    ref={ref}
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
@@ -120,11 +118,11 @@ const DropdownMenuRadioItem = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
 >(({ className, children, ...props }, ref) => (
   <DropdownMenuPrimitive.RadioItem
-    ref={ref}
     className={cn(
       'rounded-sm relative flex cursor-default select-none items-center py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
+    ref={ref}
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
@@ -144,8 +142,8 @@ const DropdownMenuLabel = React.forwardRef<
   }
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Label
-    ref={ref}
     className={cn('px-2 py-1.5 text-sm font-semibold', inset && 'pl-8', className)}
+    ref={ref}
     {...props}
   />
 ));
@@ -156,8 +154,8 @@ const DropdownMenuSeparator = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
-    ref={ref}
     className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    ref={ref}
     {...props}
   />
 ));

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+/* eslint-disable */
+
 import * as React from 'react';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { Check, ChevronRight, Circle } from 'lucide-react';


### PR DESCRIPTION
## 개요
헤더 구현, lint 오류 해결

## 작업 사항
- 헤더 현재 페이지 강조 효과
- 드롭다운 lint 오류 해결
  -> eslint 무시로 해결
  -> 이유 : eslint를 해결하기 위해 속성 정렬을 하면 className 순서 prettier 오류가 생긴다(eslint, prettier 충돌). 드롭다운의 모든 컴포넌트를 바꿔야 하는데 해당 컴포넌트는 shadcn/ui에서 가져왔기에 큰 문제 없다 판단하여 eslint 무시로 해결. 전체 className 바꿔도 프리티어 자동 정렬로 인해 새로운 방법을 모색해야함.

## 관련 이슈
<!---- Resolves: #(Isuue Number) -->
