### PR TITLE
리액트 쿼리 queryClient 옵션 설정

### DIFF
--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -1,0 +1,11 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 0,
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  },
+});

--- a/src/components/react-query-providers.tsx
+++ b/src/components/react-query-providers.tsx
@@ -1,22 +1,10 @@
 'use client';
-import { useState } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { queryClient } from '@/api/query-client';
 
 export default function ReactQueryProviders({ children }: React.PropsWithChildren) {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            // With SSR, we usually want to set some default staleTime
-            // above 0 to avoid refetching immediately on the client
-            staleTime: 60 * 1000,
-          },
-        },
-      }),
-  );
-
   return (
     <QueryClientProvider client={queryClient}>
       {children}


### PR DESCRIPTION
## 개요
queryClient 분리, 옵션 설정
## 작업 사항
- queryClient부분은 api 폴더에 가깝게 두는게 좋을 것 같아 api/queryClient.ts로 분리
- 최신 데이터만 보여주기 위해 staleTime을 0으로 설정
- 추가적으로 많은 네트워크 요청을 방지하기 위해 refetchOnWindowFocus, retry 옵션도 false로 설정.
## 관련 이슈
<!---- Resolves: #(Isuue Number) -->
Resolves: #127 