### PR TITLE
게시글 상세 모바일 UI 수정

### DIFF
--- a/src/app/post/[postId]/page.tsx
+++ b/src/app/post/[postId]/page.tsx
@@ -80,7 +80,7 @@ export default function PostPage({ params }: PostPageProps) {
   return (
     <Box>
       <div className="text-2xl">{post?.title}</div>
-      <div className="flex justify-between">
+      <div className="flex flex-col justify-between gap-3 sm:flex-row">
         <div className="flex items-center gap-2">
           <div className="h-9 w-9 rounded-full bg-gray-400" />
           <div>{post?.memberName}</div>


### PR DESCRIPTION
## 개요
게시글 상세 모바일 UI 수정
## 작업 사항
- 모바일에서의 게시글 상세의 닉네임 외 메타데이터를 닉네임 밑으로 내리게 수정
![image](https://github.com/user-attachments/assets/bfa6ab70-4e72-4434-a430-457a95518123)

## 관련 이슈
<!---- Resolves: #(Isuue Number) -->
Resolves: #137 